### PR TITLE
27 use platform specific directories for log file instead of relative directory

### DIFF
--- a/ph-sensor/Cargo.toml
+++ b/ph-sensor/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1.0.197", features = ["derive"] }
 ctrlc = "3.4.2"
 serde_json = "1.0.114"
 rand = "0.8.5"
+platform-dirs = "0.3.0"

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use platform_dirs::AppDirs;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -72,7 +73,8 @@ pub fn sensor_loop(
 
 fn _add_reading_to_reading_log() {
     println!("Adding reading");
-    let log_path = "../../reading_log";
+    let app_dirs = AppDirs::new(Some("ph_sensor"), false).unwrap();
+    let log_path = app_dirs.data_dir.join("reading_log");
 
     let mut file = OpenOptions::new()
         .read(true)

--- a/ph-sensor/src/sensor.rs
+++ b/ph-sensor/src/sensor.rs
@@ -76,6 +76,9 @@ fn _add_reading_to_reading_log() {
     let app_dirs = AppDirs::new(Some("ph_sensor"), false).unwrap();
     let log_path = app_dirs.data_dir.join("reading_log");
 
+    // Create directory if it doesn't exist
+    std::fs::create_dir_all(&app_dirs.data_dir).unwrap();
+
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)


### PR DESCRIPTION
Closes #27 

If we add a `dbg!(&log_path)` and run we see it expects to put the log at `~/Library/Application\ Support/ph_sensor/reading_log`
<img width="866" alt="image" src="https://github.com/emily-bytes/Plant-pH-Monitor/assets/17811745/603a97b8-a3f7-48e6-a60b-914aca294cb0">

We can see the first `ls | grep ph_sensor` shows the path doesn't exist, but after running the ph sensor, the directory is created and the log has the contents we expect
<img width="922" alt="image" src="https://github.com/emily-bytes/Plant-pH-Monitor/assets/17811745/320ab28c-c467-4118-92f6-e03c3c176879">
